### PR TITLE
Save and track successful Kusto queries

### DIFF
--- a/src/ClassLibrary1/ClearwaterChatService.cs
+++ b/src/ClassLibrary1/ClearwaterChatService.cs
@@ -51,6 +51,9 @@ namespace Microsoft.AzureCore.ReadyToDeploy.Vira
             // Add assistant's response to the chat history
             _chatHistory.AddAssistantMessage(result.Content!);
 
+            // Save the successful query and its result
+            await KustoHelper.SaveSuccessfulQuery(userInput, result.Content!);
+
             return result.Content!;
         }
     }

--- a/src/ClassLibrary1/Plugins.cs
+++ b/src/ClassLibrary1/Plugins.cs
@@ -32,7 +32,11 @@ namespace Microsoft.AzureCore.ReadyToDeploy.Vira
         public async Task<string> GetBuildInfoAsync(
             [Description("The name of the organization (e.g., 'msazure').")] string orgName,
             [Description("The build ID to look up.")] string buildId)
-            => await ExecuteAndLogQueryAsync("Build", orgName, buildId, "No build found");
+        {
+            var result = await ExecuteAndLogQueryAsync("Build", orgName, buildId, "No build found");
+            await KustoHelper.SaveSuccessfulQuery($"Build info query for Org: {orgName}, BuildId: {buildId}", result);
+            return result;
+        }
 
         /// <summary>
         /// Retrieves work items linked to a specific build.
@@ -43,7 +47,11 @@ namespace Microsoft.AzureCore.ReadyToDeploy.Vira
         public async Task<string> GetWorkItemsByBuildAsync(
             [Description("The name of the organization (e.g., 'msazure').")] string orgName,
             [Description("The build ID to look up.")] string buildId)
-            => await ExecuteAndLogQueryAsync("BuildWorkItem", orgName, buildId, "No work items found");
+        {
+            var result = await ExecuteAndLogQueryAsync("BuildWorkItem", orgName, buildId, "No work items found");
+            await KustoHelper.SaveSuccessfulQuery($"Work items query for Org: {orgName}, BuildId: {buildId}", result);
+            return result;
+        }
 
         /// <summary>
         /// Retrieves commits linked to a specific build.
@@ -54,7 +62,11 @@ namespace Microsoft.AzureCore.ReadyToDeploy.Vira
         public async Task<string> GetCommitsByBuildAsync(
             [Description("The name of the organization (e.g., 'msazure').")] string orgName,
             [Description("The build ID to look up.")] string buildId)
-            => await ExecuteAndLogQueryAsync("BuildChange", orgName, buildId, "No commits found");
+        {
+            var result = await ExecuteAndLogQueryAsync("BuildChange", orgName, buildId, "No commits found");
+            await KustoHelper.SaveSuccessfulQuery($"Commits query for Org: {orgName}, BuildId: {buildId}", result);
+            return result;
+        }
 
         /// <summary>
         /// Retrieves Pull Requests linked to a specific build by performing a join between BuildChange and PullRequest.
@@ -70,6 +82,8 @@ namespace Microsoft.AzureCore.ReadyToDeploy.Vira
 
             var pullRequests = await KustoHelper.RetrievePullRequestsByBuildIdAsync(orgName, buildId);
             Logger.LogJson("Tool", pullRequests);
+
+            await KustoHelper.SaveSuccessfulQuery($"Pull requests query for Org: {orgName}, BuildId: {buildId}", pullRequests);
 
             return string.IsNullOrEmpty(pullRequests) ? $"No pull requests found for Org: {orgName} and BuildId: {buildId}" : pullRequests;
         }
@@ -150,6 +164,8 @@ namespace Microsoft.AzureCore.ReadyToDeploy.Vira
                 return HandleLargeResponse(result);
             }
 
+            await KustoHelper.SaveSuccessfulQuery($"Kusto query for Cluster: {clusterKey}, Query: {query}", result);
+
             return result ?? "No results found.";
         }
 
@@ -206,6 +222,8 @@ namespace Microsoft.AzureCore.ReadyToDeploy.Vira
             string query = $".show database {clusterKey} cslschema";
             var result = await KustoHelper.ExecuteKustoQueryForClusterWithoutPaginationAsync(cluster.Uri, cluster.DatabaseName, query);
             Logger.LogJson("Tool", result);
+
+            await KustoHelper.SaveSuccessfulQuery($"List tables query for Cluster: {clusterKey}", result);
 
             return result ?? "No tables found.";
         }

--- a/src/ClassLibrary1/README.md
+++ b/src/ClassLibrary1/README.md
@@ -1,1 +1,51 @@
+# ClassLibrary1
 
+## Save and Track Successful Kusto Queries
+
+This library now includes functionality to save and track successful Kusto queries. The queries can be stored locally or in CosmosDB based on the configuration.
+
+### Configuration
+
+To configure the storage type, update the `appsettings.json` file with the desired storage type and settings.
+
+#### Local Storage
+
+To store queries locally, set the `StorageType` to `local` and provide the file path.
+
+```json
+{
+  "StorageType": "local",
+  "LocalStorage": {
+    "FilePath": "queryHistory.json"
+  }
+}
+```
+
+#### CosmosDB Storage
+
+To store queries in CosmosDB, set the `StorageType` to `cosmosdb` and provide the connection details.
+
+```json
+{
+  "StorageType": "cosmosdb",
+  "CosmosDB": {
+    "ConnectionString": "your-cosmosdb-connection-string",
+    "DatabaseName": "your-database-name",
+    "ContainerName": "your-container-name"
+  }
+}
+```
+
+### Usage
+
+The `SaveSuccessfulQuery` method in `Utilities.cs` is used to save successful queries. This method is called after a successful query execution in `ClearwaterChatService.cs` and `Plugins.cs`.
+
+### Example
+
+Here is an example of how to use the `SaveSuccessfulQuery` method:
+
+```csharp
+await KustoHelper.SaveSuccessfulQuery(query, result);
+```
+
+This will save the query and its result based on the configured storage type.

--- a/src/ClassLibrary1/appsettings.json
+++ b/src/ClassLibrary1/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "StorageType": "local", // Options: "local" or "cosmosdb"
+  "LocalStorage": {
+    "FilePath": "queryHistory.json"
+  },
+  "CosmosDB": {
+    "ConnectionString": "your-cosmosdb-connection-string",
+    "DatabaseName": "your-database-name",
+    "ContainerName": "your-container-name"
+  }
+}


### PR DESCRIPTION
Fixes #3

Implement functionality to save and track successful Kusto queries.

* **Utilities.cs**:
  - Add `SaveSuccessfulQuery` method to save successful queries locally or in CosmosDB.
  - Implement `SaveQueryLocally` and `SaveQueryToCosmosDB` methods.
  - Add `ConfigurationHelper` class to retrieve configuration settings.

* **ClearwaterChatService.cs**:
  - Modify `GetChatResponseAsync` method to call `SaveSuccessfulQuery` after a successful query execution.

* **Plugins.cs**:
  - Update Kusto-related plugins to call `SaveSuccessfulQuery` after each successful query execution.

* **appsettings.json**:
  - Add configuration options to specify storage type (local or CosmosDB) and settings for CosmosDB connection.

* **README.md**:
  - Update documentation to include information about the new functionality to save and track successful Kusto queries.
  - Provide instructions on how to configure the storage type (local or CosmosDB).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/azure-openai-kusto-chat/issues/3?shareId=28271908-fcac-4654-abdd-72e2e0c3e00f).