### PR TITLE
Simplify existing code with a clean separation between services, plugins, and clients

### DIFF
--- a/src/ClassLibrary1/Clients/KustoClient.cs
+++ b/src/ClassLibrary1/Clients/KustoClient.cs
@@ -1,0 +1,122 @@
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Clients
+{
+    using System;
+    using System.Data;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Kusto.Data;
+    using Kusto.Data.Common;
+    using Kusto.Data.Net.Client;
+
+    using Newtonsoft.Json;
+
+    public static class KustoClient
+    {
+        /// <summary>
+        /// Executes a Kusto query for a specific cluster and database without pagination.
+        /// </summary>
+        public static async Task<string> ExecuteKustoQueryForClusterWithoutPaginationAsync(string clusterUri, string databaseName, string query, CancellationToken cancellationToken = default)
+        {
+            KustoHelperFunctions.LogQuery(query);
+
+            var credentials = new KustoConnectionStringBuilder(clusterUri)
+                .WithAadAzureTokenCredentialsAuthentication(CredentialHelper.CreateChainedCredential());
+
+            using (var kustoClient = KustoClientFactory.CreateCslQueryProvider(credentials))
+            {
+                var clientRequestProperties = new ClientRequestProperties
+                {
+                    ClientRequestId = Guid.NewGuid().ToString(),
+                    Application = "DevOpsPlugin"
+                };
+                clientRequestProperties.SetOption("query_timeout", "00:05:00"); // 5 minutes timeout
+
+                using (var reader = await kustoClient.ExecuteQueryAsync(databaseName, query, clientRequestProperties, cancellationToken).ConfigureAwait(false))
+                {
+                    var dataTable = new DataTable();
+                    dataTable.Load(reader);
+                    return JsonConvert.SerializeObject(dataTable);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Executes a Kusto query for a specific cluster and database with optional pagination.
+        /// </summary>
+        public static async Task<string> ExecuteKustoQueryForClusterWithPaginationAsync(string clusterUri, string databaseName, string query, bool paginated = true, int pageSize = 1000, int pageIndex = 0, CancellationToken cancellationToken = default)
+        {
+            string paginatedQuery = paginated
+                ? $"{query} | skip {pageSize * pageIndex} | take {pageSize}"
+                : query;
+
+            KustoHelperFunctions.LogQuery(paginatedQuery);
+
+            var credentials = new KustoConnectionStringBuilder(clusterUri)
+                .WithAadAzureTokenCredentialsAuthentication(CredentialHelper.CreateChainedCredential());
+
+            using (var kustoClient = KustoClientFactory.CreateCslQueryProvider(credentials))
+            {
+                var clientRequestProperties = new ClientRequestProperties
+                {
+                    ClientRequestId = Guid.NewGuid().ToString(),
+                    Application = "DevOpsPlugin"
+                };
+                clientRequestProperties.SetOption("query_timeout", "00:05:00"); // 5 minutes timeout
+
+                using (var reader = await kustoClient.ExecuteQueryAsync(databaseName, paginatedQuery, clientRequestProperties, cancellationToken).ConfigureAwait(false))
+                {
+                    var dataTable = new DataTable();
+                    dataTable.Load(reader);
+                    return JsonConvert.SerializeObject(dataTable);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Executes a general Kusto query with optional parameters.
+        /// </summary>
+        public static async Task<string> ExecuteKustoQueryAsync(string clusterUri, string databaseName, string kustoQuery, object? parameters = null, CancellationToken cancellationToken = default)
+        {
+            KustoHelperFunctions.LogQuery(kustoQuery);
+
+            var credentials = new KustoConnectionStringBuilder(clusterUri)
+                .WithAadAzureTokenCredentialsAuthentication(CredentialHelper.CreateChainedCredential());
+
+            using (var kustoClient = KustoClientFactory.CreateCslQueryProvider(credentials))
+            {
+                var clientRequestProperties = new ClientRequestProperties
+                {
+                    ClientRequestId = Guid.NewGuid().ToString(),
+                    Application = "DevOpsPlugin"
+                };
+                if (parameters != null)
+                {
+                    InjectQueryParameters(clientRequestProperties, parameters);
+                }
+
+                using (var reader = await kustoClient.ExecuteQueryAsync(databaseName, kustoQuery, clientRequestProperties, cancellationToken).ConfigureAwait(false))
+                {
+                    var dataTable = new DataTable();
+                    dataTable.Load(reader);
+                    return JsonConvert.SerializeObject(dataTable);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Injects query parameters into the ClientRequestProperties for the Kusto query.
+        /// </summary>
+        private static void InjectQueryParameters(ClientRequestProperties properties, object parameters)
+        {
+            foreach (var prop in parameters.GetType().GetProperties())
+            {
+                var value = prop.GetValue(parameters);
+                if (value != null)
+                {
+                    properties.SetParameter(prop.Name, value.ToString());
+                }
+            }
+        }
+    }
+}

--- a/src/ClassLibrary1/Helpers/KustoHelperFunctions.cs
+++ b/src/ClassLibrary1/Helpers/KustoHelperFunctions.cs
@@ -1,0 +1,29 @@
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Helpers
+{
+    using System;
+
+    internal static class KustoHelperFunctions
+    {
+        /// <summary>
+        /// Logs the query to the console.
+        /// </summary>
+        public static void LogQuery(string query)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkRed;
+            Console.WriteLine($"Kusto Query: {query}");
+            Console.ResetColor();
+        }
+
+        /// <summary>
+        /// Escapes special characters in Kusto string literals.
+        /// </summary>
+        public static string EscapeKustoString(string input) => input.Replace("'", "''");
+
+        /// <summary>
+        /// Escapes special characters in Kusto identifiers.
+        /// </summary>
+        public static string EscapeKustoIdentifier(string input) =>
+            // Add any necessary escaping for identifiers if needed
+            input;
+    }
+}

--- a/src/ClassLibrary1/Plugins/AzureDevOpsPlugin.cs
+++ b/src/ClassLibrary1/Plugins/AzureDevOpsPlugin.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins
 {
     using System;
     using System.ComponentModel;
@@ -19,16 +19,23 @@
     /// </summary>
     public class AzureDevOpsPlugin : PluginBase
     {
-        private readonly WorkItemTrackingHttpClient _workItemClient;
-        private readonly string _defaultProject;
+        private WorkItemTrackingHttpClient _workItemClient;
+        private string _defaultProject;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureDevOpsPlugin"/> class.
         /// </summary>
+        public AzureDevOpsPlugin()
+        {
+        }
+
+        /// <summary>
+        /// Initializes the Azure DevOps client with necessary configurations.
+        /// </summary>
         /// <param name="personalAccessToken">Azure DevOps Personal Access Token for authentication.</param>
         /// <param name="organizationUrl">The Azure DevOps organization URL (e.g., https://dev.azure.com/yourorganization).</param>
         /// <param name="defaultProject">The default project name where work items will be created.</param>
-        public AzureDevOpsPlugin(string personalAccessToken, string organizationUrl, string defaultProject)
+        public void InitializeClient(string personalAccessToken, string organizationUrl, string defaultProject)
         {
             if (string.IsNullOrWhiteSpace(personalAccessToken))
                 throw new ArgumentException("Personal Access Token cannot be null or empty.", nameof(personalAccessToken));

--- a/src/ClassLibrary1/Plugins/KustoPlugin.cs
+++ b/src/ClassLibrary1/Plugins/KustoPlugin.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins
 {
     using System;
     using System.Collections.Generic;
@@ -9,25 +9,29 @@
 
     using Microsoft.SemanticKernel;
 
-    public class KustoPlugin
+    public class KustoPlugin : PluginBase
     {
         private readonly Dictionary<string, KustoClusterConfig> _clusters;
-        private static readonly string[] value = new[]
-                    {
-                        "Update the query with important columns by adding a '| project' section.",
-                        "Use 'kusto_query_count' to determine the number of results in your previous query.",
-                        "If the issue continues, add a 'take' statement or decrease the number of rows taken if it was already included.",
-                    };
 
         // Constructor that initializes clusters with unique keys
         public KustoPlugin()
         {
-            _clusters = new Dictionary<string, KustoClusterConfig>
+            _clusters = new Dictionary<string, KustoClusterConfig>();
+        }
+
+        /// <summary>
+        /// Initializes the Kusto client with necessary configurations.
+        /// </summary>
+        /// <param name="clusters">Dictionary of Kusto clusters to initialize.</param>
+        public void InitializeClient(Dictionary<string, KustoClusterConfig> clusters)
+        {
+            if (clusters == null || clusters.Count == 0)
+                throw new ArgumentException("Clusters cannot be null or empty.", nameof(clusters));
+
+            foreach (var cluster in clusters)
             {
-                { "safefly", new KustoClusterConfig("safefly", "https://safeflycluster.westus.kusto.windows.net/", "safefly", "Deployment Requests linked with Build ID") },
-                { "copilot", new KustoClusterConfig("copilot", "https://az-copilot-kusto.eastus.kusto.windows.net/", "copilotDevFeedback", "Copilot Risk reports for SafeFly requests based on compared builds of sequential requests") },
-                { "azuredevops", new KustoClusterConfig("azuredevops", "https://1es.kusto.windows.net/", "AzureDevOps", "Contains Builds, Pull Requests, Commits, and Work Items") }
-            };
+                _clusters[cluster.Key] = cluster.Value;
+            }
         }
 
         /// <summary>
@@ -208,7 +212,12 @@
                 return JsonSerializer.Serialize(new
                 {
                     message = $"The response length was {result.Length} characters and exceeded the token limit.",
-                    suggestions = value
+                    suggestions = new[]
+                    {
+                        "Update the query with important columns by adding a '| project' section.",
+                        "Use 'kusto_query_count' to determine the number of results in your previous query.",
+                        "If the issue continues, add a 'take' statement or decrease the number of rows taken if it was already included.",
+                    }
                 }, new JsonSerializerOptions { WriteIndented = true });
             }
 

--- a/src/ClassLibrary1/Plugins/PluginBase.cs
+++ b/src/ClassLibrary1/Plugins/PluginBase.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins
 {
     using System;
     using System.Text.Json;
@@ -13,9 +13,7 @@
         /// Initializes the plugin. Can be overridden by derived classes for custom initialization.
         /// </summary>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task InitializeAsync() =>
-            // Default implementation (can be overridden)
-            Task.CompletedTask;
+        public abstract Task InitializeAsync();
 
         /// <summary>
         /// Executes the plugin's primary function. Must be implemented by derived classes.

--- a/src/ClassLibrary1/Program.cs
+++ b/src/ClassLibrary1/Program.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.AzureCore.ReadyToDeploy.Vira
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira
 {
     /// <summary>
     /// Entry point for the Clearwater Chat REPL application.
@@ -12,11 +12,12 @@
         /// </summary>
         public static async Task Main(string[] args)
         {
-            // Azure OpenAI API Setup
-            string deploymentName = "gpt-4o-mini";
-            string endpoint = "https://gpt-review.openai.azure.com";
+            // Initialize services
+            var serviceInitializer = new ServiceInitializer();
+            var chatService = serviceInitializer.InitializeClearwaterChatService("gpt-4o-mini", "https://gpt-review.openai.azure.com");
 
-            var chatService = new ClearwaterChatService(deploymentName, endpoint);
+            // Initialize plugins
+            chatService.InitializePlugins();
 
             // REPL loop for interactive chat
             Console.WriteLine("Welcome to the Clearwater Chat REPL! Try asking me about ADO Org Build Id. Type 'exit' to quit.");

--- a/src/ClassLibrary1/Services/ClearwaterChatService.cs
+++ b/src/ClassLibrary1/Services/ClearwaterChatService.cs
@@ -1,0 +1,63 @@
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Services
+{
+    using global::Microsoft.SemanticKernel;
+    using global::Microsoft.SemanticKernel.ChatCompletion;
+    using global::Microsoft.SemanticKernel.Connectors.OpenAI;
+
+    using Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins;
+
+    /// <summary>
+    /// A service for managing chat interactions using Azure OpenAI with persistent chat history.
+    /// </summary>
+    public class ClearwaterChatService
+    {
+        private readonly Kernel _kernel;
+        private readonly ChatHistory _chatHistory;
+
+        // Initialize chat history in the constructor
+        public ClearwaterChatService(string deploymentName, string endpoint)
+        {
+            var builder = Kernel.CreateBuilder();
+            builder.AddAzureOpenAIChatCompletion(deploymentName, endpoint, CredentialHelper.CreateChainedCredential());
+
+            _kernel = builder.Build();
+
+            // Initialize the chat history to persist across multiple interactions
+            _chatHistory = new ChatHistory("How can I assist you today?");
+        }
+
+        // Method to initialize plugins
+        public void InitializePlugins()
+        {
+            _kernel.Plugins.AddFromType<ClearwaterPlugin>();
+            _kernel.Plugins.AddFromType<KustoPlugin>();
+            _kernel.Plugins.AddFromType<DevOpsPlugin>();
+            _kernel.Plugins.AddFromType<MetaPlugin>();
+            // _kernel.Plugins.AddFromType<SafeFlyPlugin>();
+        }
+
+        // Method now reuses chat history
+        public async Task<string> GetChatResponseAsync(string userInput)
+        {
+            // Add the user's message to the existing chat history
+            _chatHistory.AddUserMessage(userInput);
+
+            var openAIPromptExecutionSettings = new OpenAIPromptExecutionSettings
+            {
+                ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+            };
+
+            var chatCompletionService = _kernel.GetRequiredService<IChatCompletionService>();
+            var result = await chatCompletionService.GetChatMessageContentAsync(
+                _chatHistory,
+                executionSettings: openAIPromptExecutionSettings,
+                kernel: _kernel
+            );
+
+            // Add assistant's response to the chat history
+            _chatHistory.AddAssistantMessage(result.Content!);
+
+            return result.Content!;
+        }
+    }
+}

--- a/src/ClassLibrary1/Services/ServiceInitializer.cs
+++ b/src/ClassLibrary1/Services/ServiceInitializer.cs
@@ -1,0 +1,29 @@
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Services
+{
+    using Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins;
+
+    /// <summary>
+    /// A class to initialize services.
+    /// </summary>
+    public class ServiceInitializer
+    {
+        /// <summary>
+        /// Initializes the ClearwaterChatService.
+        /// </summary>
+        /// <param name="deploymentName">The deployment name for Azure OpenAI.</param>
+        /// <param name="endpoint">The endpoint for Azure OpenAI.</param>
+        /// <returns>An instance of ClearwaterChatService.</returns>
+        public ClearwaterChatService InitializeClearwaterChatService(string deploymentName, string endpoint)
+        {
+            return new ClearwaterChatService(deploymentName, endpoint);
+        }
+
+        /// <summary>
+        /// Initializes other services.
+        /// </summary>
+        public void InitializeOtherServices()
+        {
+            // Add initialization logic for other services here
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7

Refactor code to achieve a clear separation between services, plugins, and clients.

* **Services:**
  - Add `ClearwaterChatService` class in `src/ClassLibrary1/Services/ClearwaterChatService.cs` to manage chat interactions.
  - Add `ServiceInitializer` class in `src/ClassLibrary1/Services/ServiceInitializer.cs` to initialize services.

* **Helpers:**
  - Add `KustoHelperFunctions` class in `src/ClassLibrary1/Helpers/KustoHelperFunctions.cs` to contain helper functions for Kusto operations.

* **Clients:**
  - Add `KustoClient` class in `src/ClassLibrary1/Clients/KustoClient.cs` to handle Kusto client logic.

* **Plugins:**
  - Modify `AzureDevOpsPlugin` to remove client-specific configurations and add a method to initialize the client.
  - Modify `KustoPlugin` to remove client-specific configurations and add a method to initialize the client.
  - Modify `PluginBase` to add abstract methods for initialization, execution, and help.

* **Program:**
  - Modify `Program.cs` to remove direct service initialization and add a call to `ServiceInitializer` to initialize services.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/azure-openai-kusto-chat/issues/7?shareId=6b9aa508-cafe-48b0-9085-cfe1c8ad5c71).