### PR TITLE
Fix Kusto function validation

### DIFF
--- a/src/ClassLibrary1/Plugins/KustoPlugin.cs
+++ b/src/ClassLibrary1/Plugins/KustoPlugin.cs
@@ -217,9 +217,10 @@
             }
 
             if (string.IsNullOrWhiteSpace(functionDefinition) ||
-                !functionDefinition.Trim().StartsWith(".create function", StringComparison.OrdinalIgnoreCase) || !functionDefinition.Trim().StartsWith(".alter function", StringComparison.OrdinalIgnoreCase))
+                !(functionDefinition.Trim().StartsWith(".create function", StringComparison.OrdinalIgnoreCase) ||
+                  functionDefinition.Trim().StartsWith(".alter function", StringComparison.OrdinalIgnoreCase)))
             {
-                return CreateErrorResponse("Invalid function definition. Ensure it begins with '.create function'.");
+                return CreateErrorResponse("Invalid function definition. Ensure it begins with '.create function' or '.alter function'.");
             }
 
             try


### PR DESCRIPTION
## Summary
- fix logic that validates Kusto function definitions

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*