### PR TITLE
Add Kusto function tests

### DIFF
--- a/src/ClassLibrary1/Helpers/KustoHelper.cs
+++ b/src/ClassLibrary1/Helpers/KustoHelper.cs
@@ -97,7 +97,16 @@
         /// <param name="command">The Kusto administrative command to execute.</param>
         /// <param name="cancellationToken">A cancellation token for managing the asynchronous operation.</param>
         /// <returns>A JSON string indicating success or an error message.</returns>
-        internal static async Task<string> ExecuteAdminCommandAsync(
+        internal static Func<string, string, string, CancellationToken, Task<string>> ExecuteAdminCommandAsyncFunc { get; set; } = RealExecuteAdminCommandAsync;
+
+        internal static Task<string> ExecuteAdminCommandAsync(
+            string clusterUri,
+            string databaseName,
+            string command,
+            CancellationToken cancellationToken = default)
+            => ExecuteAdminCommandAsyncFunc(clusterUri, databaseName, command, cancellationToken);
+
+        private static async Task<string> RealExecuteAdminCommandAsync(
             string clusterUri,
             string databaseName,
             string command,

--- a/src/ClassLibrary1/Plugins/KustoPlugin.cs
+++ b/src/ClassLibrary1/Plugins/KustoPlugin.cs
@@ -217,9 +217,10 @@
             }
 
             if (string.IsNullOrWhiteSpace(functionDefinition) ||
-                !functionDefinition.Trim().StartsWith(".create function", StringComparison.OrdinalIgnoreCase) || !functionDefinition.Trim().StartsWith(".alter function", StringComparison.OrdinalIgnoreCase))
+                !(functionDefinition.Trim().StartsWith(".create function", StringComparison.OrdinalIgnoreCase) ||
+                  functionDefinition.Trim().StartsWith(".alter function", StringComparison.OrdinalIgnoreCase)))
             {
-                return CreateErrorResponse("Invalid function definition. Ensure it begins with '.create function'.");
+                return CreateErrorResponse("Invalid function definition. Ensure it begins with '.create function' or '.alter function'.");
             }
 
             try

--- a/src/ClassLibrary1/Properties/AssemblyInfo.cs
+++ b/src/ClassLibrary1/Properties/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Microsoft.AzureCore.ReadyToDeploy.Vira.Tests")]

--- a/src/Microsoft.AzureCore.ReadyToDeploy.Vira.Tests/KustoPluginTests.cs
+++ b/src/Microsoft.AzureCore.ReadyToDeploy.Vira.Tests/KustoPluginTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AzureCore.ReadyToDeploy.Vira.Plugins;
+using Microsoft.AzureCore.ReadyToDeploy.Vira.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.AzureCore.ReadyToDeploy.Vira.Tests;
+
+[TestClass]
+public class KustoPluginTests
+{
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        // restore default delegate
+        KustoHelper.ExecuteAdminCommandAsyncFunc = typeof(KustoHelper)
+            .GetMethod("RealExecuteAdminCommandAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
+            .CreateDelegate(typeof(Func<string, string, string, CancellationToken, Task<string>>)) as Func<string, string, string, CancellationToken, Task<string>>;
+    }
+
+    [DataTestMethod]
+    [DataRow(".create function f(){print 1}")]
+    [DataRow(".alter function f(){print 1}")]
+    public async Task CreateKustoFunctionAsync_AllowsCreateAndAlter(string command)
+    {
+        // Arrange
+        var plugin = new KustoPlugin();
+        KustoHelper.ExecuteAdminCommandAsyncFunc = (clusterUri, db, cmd, ct) =>
+            Task.FromResult("{ \"success\": true, \"message\": \"Command executed successfully.\" }");
+
+        // Act
+        string result = await plugin.CreateKustoFunctionAsync(command, CancellationToken.None);
+
+        // Assert
+        Assert.IsFalse(string.IsNullOrEmpty(result), "Response should not be empty");
+        Assert.IsTrue(result.Contains("success"), $"Unexpected response: {result}");
+    }
+}


### PR DESCRIPTION
## Summary
- add delegate hook for KustoHelper admin command
- fix validation in `CreateKustoFunctionAsync`
- expose internals to test project
- add unit tests for creating Kusto functions

## Testing
- `dotnet test --no-restore src/Microsoft.AzureCore.ReadyToDeploy.Vira.Tests/Microsoft.AzureCore.ReadyToDeploy.Vira.Tests.csproj` *(fails: Assets file not found)*